### PR TITLE
argument parser error checking (#10)

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -9,7 +9,10 @@
             "compilerPath": "/usr/bin/gcc",
             "cppStandard": "c++14",
             "intelliSenseMode": "linux-clang-x64",
-            "cStandard": "c11"
+            "cStandard": "c11",
+            "defines": [
+                "USE_STREAMING_INPUT=1"
+            ]
         }
     ],
     "version": 4

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 ## v3.0.0
 
-* Merged argument parsing implementations together into one file.
+* [ba250c4](ba250c452722f32677621eba5157b8c1173d0f34)
+    * Merged argument parsing implementations together into one file.  This was a backwards incompatible change around how argument parsing without streaming was done, and so required the major version bump to 3.
+* (change tbd)
+    * Marked REQUIRE_FULL_CMD as a top-level makefile flag.
+    * Added argument parser error checking (#10).  With this, the argument parsing routine was rewritten which made the compled version smaller.  This significantly changes how non `-c` argument parsing is handled now, and it may not be supported for v3.0.
+    * Fixed a bug with the `exec` command when the exec call out fails.  Before, the error was ignored.  Added a test to cover this (`exec-not-a-command.sh`).
 
 
 ## v2.0.2

--- a/Makefile.command-flags
+++ b/Makefile.command-flags
@@ -27,6 +27,8 @@ CMD_TRUNC = -DUSE_CMD_TRUNC
 
 # These flags indicate additional features that aren't commands.
 STREAMING_INPUT = -DUSE_STREAMING_INPUT
+REQUIRE_FULL_CMD = -DREQUIRE_FULL_CMD
+
 
 # END LIST
 

--- a/TODO.md
+++ b/TODO.md
@@ -3,26 +3,27 @@
 Here's what's planned for the future of the tool.  Because of the backwards compatibility issues, this will be a major version bump.  With that, the tool will be renamed to "Precision Shell", because the Hadoop system has a "file system shell" that makes searching for `fs-shell` hard.
 
 
-## Join Code for Input Parsing
-
-The code bases for streaming input support is different than the argv parsing, and leads to subtle differences in how arguments are handled.  This change will unify those code bases and remove those differences.
-
-
-## Error Parsing Error Codes
-
-Currently, parsing arguments does not indicate errors, such as file reading errors.  To correct this, argument parsing will return a pointer to a structure that contains the argument and a state value.
-
-
 ## Environment Variable Parsing
+
+Issue #11
 
 The environment variables will be interpreted within the parsing of the commands, assuming the env handling flag is turned on.  Environment variables must be in the form `${VALUE}`; the standard shell supported syntax of `$VALUE` will not be supported.
 
 
-## Change Quoting
+## Change Argument Quoting
+
+Issue #12
 
 The argument quoting will change to allow for better embedded arguments.  The current candidate for quoting are the characters `[` (start) and `]` (end).  This becomes more necessary when the sub-command parsing is implemented.
 
 
-## Sub-Commands
+## Sub-Command Support
+
+Issue #13
 
 The special command `(` will cause the shell to enter a sub-command, allowing for propigation of error codes to the outer command.  The special argument `)` will mark the end of a command, only if it is not quoted.  Due to this, argument parsing will need to include marking whether an argument includes quoting or not.
+
+
+## Command Line Arguments
+
+Historically, arguments were used as-is, assuming the calling program already parsed them.  Starting with v3, the parsing algorithm significantly changed to support the much more common use case of "-c" argument parsing.  This raises the question if the old command line parsing should be maintained?  No other major shell supports this execution mode.

--- a/src/Makefile
+++ b/src/Makefile
@@ -54,7 +54,7 @@ COMMAND_HEADERS_DIR = ./gen-cmd
 #   we will see this appear.
 # switch is disabled because there are command enums that are markers rather than
 #   real values to switch on.
-CFLAGS += -Wall -pedantic -Wno-unused-variable -Wswitch -I$(COMMAND_HEADERS_DIR) -I.
+CFLAGS += -Wall -pedantic -Wno-unused-variable -Wno-switch -I$(COMMAND_HEADERS_DIR) -I.
 OUTDIR = ../out
 SRC = main.c helpers.c globals.c command_runner.c args.c
 

--- a/src/args.h
+++ b/src/args.h
@@ -24,6 +24,57 @@ SOFTWARE.
 #ifndef FS_SHELL_ARGS
 #define FS_SHELL_ARGS
 
+
+/**
+ * @brief Details on the argument parsing.
+ * 
+ */
+enum ArgumentDesc {
+    // Normal character.  No escaping or quoting of the text.
+    ARG_STATE_NORMAL,
+
+    // The argument included either quoted or escaped text.
+    ARG_STATE_ESCAPED,
+
+    // Note on the enum: all "argument is fine" is before _END,
+    //   and all "stop parsing arguments" is on or after _END.
+
+    // This is the last argument.  The arg may be NULL, may not be.
+    //   This is different from a zero-length argument, where the arg value
+    //   is not null but the first character is a zero.
+    ARG_STATE_END,
+
+    // The parser encountered an error while loading this argument.
+    //   The parser already reported the error.
+    ARG_STATE_ERR
+};
+
+// Configurable argument maximum size.
+//   By making this configurable, it means the tool is better
+//   able to be sized into memory constrained environments.
+//   The "save count" relates to the commands that need to hold on to
+//   the memory.
+#ifndef PARSED_ARG_SIZE
+#define PARSED_ARG_SIZE    1000
+#endif
+#ifndef PARSED_ARG_SAVE_COUNT
+#define PARSED_ARG_SAVE_COUNT    4
+#endif
+
+
+/**
+ * @brief A parsed argument text and a description about what it was like.
+ * 
+ * The argument pointer can be saved up to the PARSED_ARG_SAVE_COUNT.  After
+ * that many arguments, the previous arguments will no longer point to the
+ * original data.
+ */
+typedef struct {
+    const char *arg;
+    enum ArgumentDesc state;
+} Argument;
+
+
 /**
  * @brief Parse the shell execution request into tokens.
  * 
@@ -40,7 +91,7 @@ int args_setup_tokenizer(const int srcArgc, char *srcArgv[]);
  * 
  * @return const char* 
  */
-const char *args_advance_token();
+const Argument *args_advance_token();
 
 /**
  * @brief Clean out the tokenizer after using it.

--- a/src/cmd_exec.h.in
+++ b/src/cmd_exec.h.in
@@ -72,13 +72,13 @@ WithNamedStep(enum="EXEC", name="exec",
     )
 
     OnCmd(
-        /* add a trailing + 1 for the final 0, if necessary */
+        // add a trailing + 1 for the final 0, if necessary
         exec_argv = malloc((sizeof(const char *) * MAX_EXEC_ARGS) + 1);
         if (exec_argv == NULL) {
             stderrP("ERROR malloc failed\n");
             return 1;
         }
-        /* add a trailing + 1 for the final 0, if necessary */
+        // add a trailing + 1 for the final 0, if necessary
         exec_arg3 = malloc((sizeof(const char) * MAX_EXEC_ARG_LEN) + 1);
         if (exec_arg3 == NULL) {
             stderrP("ERROR malloc failed\n");
@@ -86,69 +86,56 @@ WithNamedStep(enum="EXEC", name="exec",
         }
         global_arg1_i = 0;
         global_arg2_i = 0;
-        global_arg = args_advance_token();
+        global_arg_state = args_advance_token();
         LOG(":: generating arguments\n");
-        while (global_arg != NULL) {
+        while (global_arg_state->state < ARG_STATE_END) {
             if (global_arg1_i >= MAX_EXEC_ARGS) {
                 stderrP("ERROR exec too many arguments\n");
+                // Use "return" because the command is not expected to
+                // keep the tool running.
                 return 1;
             }
             if (global_arg2_i >= MAX_EXEC_ARG_LEN) {
                 stderrP("ERROR exec argument total length exceeded\n");
+                // Use "return" because the command is not expected to
+                // keep the tool running.
                 return 1;
             }
-            /* set current argv index to point to start of argument, and advance argv index. */
+            global_arg = global_arg_state->arg;
+            // set current argv index to point to start of argument, and advance argv index.
             exec_argv[global_arg1_i++] = &(exec_arg3[global_arg2_i]);
-            /* copy the current argument into the long array */
+            // copy the current argument into the long array
             global_arg3_i = 0;
             while (global_arg[global_arg3_i] != 0 && global_arg2_i < MAX_EXEC_ARG_LEN) {
                 exec_arg3[global_arg2_i++] = global_arg[global_arg3_i++];
             }
-            /* terminate the copied argument. */
+            // terminate the copied argument.
             exec_arg3[global_arg2_i++] = 0;
             LOG(":: arg: [");
             LOG(exec_argv[global_arg1_i-1]);
             LOG("]\n");
-            global_arg = args_advance_token();
+            global_arg_state = args_advance_token();
         }
-        /* set the final argument to NULL to terminate the list of pointers. */
+        // set the final argument to NULL to terminate the list of pointers.
         exec_argv[global_arg1_i++] = NULL;
         if (global_arg1_i <= 1) {
-            /* No command to run */
+            // No command to run
             stderrP("ERROR no command\n");
+            // Use "return" because the command is not expected to
+            // keep the tool running.
             return 1;
         }
         EXEC_DEBUG_REPORT
         // This launches a new executable and terminates this one immediately.
         execvp(exec_argv[0], (char * const*) exec_argv);
 
-        // The trailing break could be eliminated here, because it won't ever be called.
+        // If the code is still running at this point, then there was an error.
+        stderrP("ERROR exec failed to launch command ");
+        stderrPLn(exec_argv[0]);
+        // Use "return" because the command is not expected to
+        // keep the tool running.
+        return 1;
     )
 )
 
 )
-
-
-#ifndef _FS_SHELL__CMD_EXEC_
-
-#define NAME__EXEC "exec"
-
-// No case execution
-#define CASE__COMMAND_INDEX__EXEC
-
-
-#ifdef USE_CMD_EXEC
-
-
-#define STARTUP__COMMAND_INDEX__EXEC
-case COMMAND_INDEX__EXEC:
-
-    // trailing break isn't necessary here.
-
-#else /* USE_CMD_EXEC */
-
-#define STARTUP__COMMAND_INDEX__EXEC
-
-
-#endif /* USE_CMD_EXEC */
-#endif /* _FS_SHELL__CMD_EXEC_ */

--- a/src/cmd_find_cmd.h.in
+++ b/src/cmd_find_cmd.h.in
@@ -23,6 +23,7 @@ AsRequired(command="find_cmd",
 
 
 #include <stdlib.h>
+#include <string.h>
 #include "output.h"
 #include "globals.h"
 #include "helpers.h"
@@ -42,24 +43,24 @@ OnInit(
     // This one does not span across commands; any step can use it as it needs.
     int tmp_val;
 
-    // The current command name being run.
-    const char *global_cmd_name = NULL;
-
     // Initialize globals.
     global_cmd = COMMAND_INDEX__FIND_CMD;
 )
 
 WithNamedStep(enum="FIND_CMD", name="<first>",
     OnArg(
-        LOG(":: find_cmd start\n");
-        global_cmd_name = global_arg;
+        // The command name can exceed the preserved argument
+        //   count, so make a copy of it.
+        strcpy(global_cmd_name, global_arg);
+        LOG(":: find_cmd start\n:: - using command name ");
+        LOGLN(global_cmd_name);
 
-        /* Assume that this will fail... */
+        // Assume that this will fail...
         global_cmd = COMMAND_INDEX__ERR;
         global_err = 1;
 
-        /* Do not check if the command is "error", as that is not */
-        /* a real callable command. */
+        // Do not check if the command is "error", as that is not
+        //   a real callable command.
         // printf(":: scanning from %d to %d\n", COMMAND_INDEX__FIND_CMD, COMMAND_INDEX__LAST_NAMED_CMD);
         for (tmp_val = COMMAND_INDEX__FIND_CMD; tmp_val < COMMAND_INDEX__LAST_NAMED_CMD; tmp_val++) {
             // printf(" - checking %d - %s\n", tmp_val, command_list_names[tmp_val]);

--- a/src/command_runner.c
+++ b/src/command_runner.c
@@ -61,8 +61,16 @@ int command_runner() {
 
     // Current command index to run.
     enum CommandIndex global_cmd;
+
     // The current argument being parsed.
+    const Argument *global_arg_state;
     const char *global_arg;
+
+    // The current command name being run.
+    //   Because a command can have more arguments than the
+    //   preserve count, this should be a copy of the input argument.
+    char global_cmd_name[PARSED_ARG_SIZE] = "";
+
     // Marker that there's an error in the current command.
     int global_err = 0;
 
@@ -72,13 +80,17 @@ int command_runner() {
     // ======================================================================
     // Argument Parsing Loop
     while (1 == 1) {
-        global_arg = args_advance_token();
-        if (global_arg == NULL) {
+        global_arg_state = args_advance_token();
+        if (global_arg_state->state == ARG_STATE_ERR) {
+            _err_count++;
+        }
+        if (global_arg_state->state >= ARG_STATE_END) {
 #ifdef REQUIRE_FULL_CMD
             _err_count += _on_cmd_end(global_cmd_name, global_cmd);
 #endif
             break;
         }
+        global_arg = global_arg_state->arg;
         // This is a long if/else block until error checking.
 
         // ==================================================================

--- a/src/gen-cmd/cmd_exec.h
+++ b/src/gen-cmd/cmd_exec.h
@@ -94,13 +94,13 @@ extern const char cmd_name_exec[];
     case COMMAND_INDEX__EXEC: \
         /* from cmd_exec.h.in:67 */ \
             /* from cmd_exec.h.in:74 */ \
-        /* add a trailing + 1 for the final 0, if necessary */ \
+        /* add a trailing + 1 for the final 0, if necessary*/ \
         exec_argv = malloc((sizeof(const char *) * MAX_EXEC_ARGS) + 1); \
         if (exec_argv == NULL) { \
             stderrP("ERROR malloc failed\n"); \
             return 1; \
         } \
-        /* add a trailing + 1 for the final 0, if necessary */ \
+        /* add a trailing + 1 for the final 0, if necessary*/ \
         exec_arg3 = malloc((sizeof(const char) * MAX_EXEC_ARG_LEN) + 1); \
         if (exec_arg3 == NULL) { \
             stderrP("ERROR malloc failed\n"); \
@@ -108,42 +108,54 @@ extern const char cmd_name_exec[];
         } \
         global_arg1_i = 0; \
         global_arg2_i = 0; \
-        global_arg = args_advance_token(); \
+        global_arg_state = args_advance_token(); \
         LOG(":: generating arguments\n"); \
-        while (global_arg != NULL) { \
+        while (global_arg_state->state < ARG_STATE_END) { \
             if (global_arg1_i >= MAX_EXEC_ARGS) { \
                 stderrP("ERROR exec too many arguments\n"); \
+                /* Use "return" because the command is not expected to*/ \
+                /* keep the tool running.*/ \
                 return 1; \
             } \
             if (global_arg2_i >= MAX_EXEC_ARG_LEN) { \
                 stderrP("ERROR exec argument total length exceeded\n"); \
+                /* Use "return" because the command is not expected to*/ \
+                /* keep the tool running.*/ \
                 return 1; \
             } \
-            /* set current argv index to point to start of argument, and advance argv index. */ \
+            global_arg = global_arg_state->arg; \
+            /* set current argv index to point to start of argument, and advance argv index.*/ \
             exec_argv[global_arg1_i++] = &(exec_arg3[global_arg2_i]); \
-            /* copy the current argument into the long array */ \
+            /* copy the current argument into the long array*/ \
             global_arg3_i = 0; \
             while (global_arg[global_arg3_i] != 0 && global_arg2_i < MAX_EXEC_ARG_LEN) { \
                 exec_arg3[global_arg2_i++] = global_arg[global_arg3_i++]; \
             } \
-            /* terminate the copied argument. */ \
+            /* terminate the copied argument.*/ \
             exec_arg3[global_arg2_i++] = 0; \
             LOG(":: arg: ["); \
             LOG(exec_argv[global_arg1_i-1]); \
             LOG("]\n"); \
-            global_arg = args_advance_token(); \
+            global_arg_state = args_advance_token(); \
         } \
-        /* set the final argument to NULL to terminate the list of pointers. */ \
+        /* set the final argument to NULL to terminate the list of pointers.*/ \
         exec_argv[global_arg1_i++] = NULL; \
         if (global_arg1_i <= 1) { \
-            /* No command to run */ \
+            /* No command to run*/ \
             stderrP("ERROR no command\n"); \
+            /* Use "return" because the command is not expected to*/ \
+            /* keep the tool running.*/ \
             return 1; \
         } \
         EXEC_DEBUG_REPORT \
         /* This launches a new executable and terminates this one immediately.*/ \
         execvp(exec_argv[0], (char * const*) exec_argv); \
-        /* The trailing break could be eliminated here, because it won't ever be called.*/ \
+        /* If the code is still running at this point, then there was an error.*/ \
+        stderrP("ERROR exec failed to launch command "); \
+        stderrPLn(exec_argv[0]); \
+        /* Use "return" because the command is not expected to*/ \
+        /* keep the tool running.*/ \
+        return 1; \
         break;
 #define RUN_CASE__EXEC
 #define REQUIRES_ADDL_ARG__EXEC
@@ -159,29 +171,4 @@ extern const char cmd_name_exec[];
 #define REQUIRES_ADDL_ARG__EXEC
 #endif /* USE_CMD_EXEC */
 
-#endif /* _FS_SHELL__CMD_EXEC_ */
-
-
-#ifndef _FS_SHELL__CMD_EXEC_
-
-#define NAME__EXEC "exec"
-
-// No case execution
-#define CASE__COMMAND_INDEX__EXEC
-
-
-#ifdef USE_CMD_EXEC
-
-
-#define STARTUP__COMMAND_INDEX__EXEC
-case COMMAND_INDEX__EXEC:
-
-    // trailing break isn't necessary here.
-
-#else /* USE_CMD_EXEC */
-
-#define STARTUP__COMMAND_INDEX__EXEC
-
-
-#endif /* USE_CMD_EXEC */
 #endif /* _FS_SHELL__CMD_EXEC_ */

--- a/src/gen-cmd/cmd_find_cmd.h
+++ b/src/gen-cmd/cmd_find_cmd.h
@@ -30,23 +30,24 @@ SOFTWARE. */
 
 
 #include <stdlib.h>
+#include <string.h>
 #include "output.h"
 #include "globals.h"
 #include "helpers.h"
 
 
 
-/* from cmd_find_cmd.h.in:52 */
+/* from cmd_find_cmd.h.in:50 */
 extern const char cmd_name_find_cmd[];
 #define ENUM_LIST__FIND_CMD \
-            /* from cmd_find_cmd.h.in:52 */ \
+            /* from cmd_find_cmd.h.in:50 */ \
             COMMAND_INDEX__FIND_CMD = 0,
 #define VIRTUAL_ENUM_LIST__FIND_CMD
 #define GLOBAL_VARDEF__FIND_CMD \
-            /* from cmd_find_cmd.h.in:52 */ \
+            /* from cmd_find_cmd.h.in:50 */ \
             const char cmd_name_find_cmd[] = "";
 #define INITIALIZE__FIND_CMD \
-            /* from cmd_find_cmd.h.in:30 */ \
+            /* from cmd_find_cmd.h.in:31 */ \
     /* Global variables common to all commands.*/ \
     /* List of command names to check.*/ \
     const char *command_list_names[COMMAND_INDEX__LAST_NAMED_CMD]; \
@@ -57,24 +58,25 @@ extern const char cmd_name_find_cmd[];
     int global_arg3_i = 0; \
     /* This one does not span across commands; any step can use it as it needs.*/ \
     int tmp_val; \
-    /* The current command name being run.*/ \
-    const char *global_cmd_name = NULL; \
     /* Initialize globals.*/ \
     global_cmd = COMMAND_INDEX__FIND_CMD; \
-            /* from cmd_find_cmd.h.in:52 */ \
+            /* from cmd_find_cmd.h.in:50 */ \
             command_list_names[COMMAND_INDEX__FIND_CMD] = cmd_name_find_cmd;
 #define STARTUP_CASE__FIND_CMD
 #define RUN_CASE__FIND_CMD \
     case COMMAND_INDEX__FIND_CMD: \
-        /* from cmd_find_cmd.h.in:52 */ \
-            /* from cmd_find_cmd.h.in:53 */ \
-        LOG(":: find_cmd start\n"); \
-        global_cmd_name = global_arg; \
-        /* Assume that this will fail... */ \
+        /* from cmd_find_cmd.h.in:50 */ \
+            /* from cmd_find_cmd.h.in:51 */ \
+        /* The command name can exceed the preserved argument*/ \
+        /*   count, so make a copy of it.*/ \
+        strcpy(global_cmd_name, global_arg); \
+        LOG(":: find_cmd start\n:: - using command name "); \
+        LOGLN(global_cmd_name); \
+        /* Assume that this will fail...*/ \
         global_cmd = COMMAND_INDEX__ERR; \
         global_err = 1; \
-        /* Do not check if the command is "error", as that is not */ \
-        /* a real callable command. */ \
+        /* Do not check if the command is "error", as that is not*/ \
+        /*   a real callable command.*/ \
         /* printf(":: scanning from %d to %d\n", COMMAND_INDEX__FIND_CMD, COMMAND_INDEX__LAST_NAMED_CMD);*/ \
         for (tmp_val = COMMAND_INDEX__FIND_CMD; tmp_val < COMMAND_INDEX__LAST_NAMED_CMD; tmp_val++) { \
             /* printf(" - checking %d - %s\n", tmp_val, command_list_names[tmp_val]);*/ \

--- a/src/helpers.c
+++ b/src/helpers.c
@@ -28,6 +28,7 @@ SOFTWARE.
 #include "helpers.h"
 
 const char empty_string[] = EMPTY_STRING;
+const char helper_str__malloc_failed[] = "ERROR malloc failed\n";
 
 
 // helper_arg_to_uint Converts the arg to an integer value

--- a/src/helpers.h
+++ b/src/helpers.h
@@ -25,15 +25,15 @@ SOFTWARE.
 #ifndef _FS_SHELL__HELPERS_
 #define _FS_SHELL__HELPERS_
 
-// This core dumps on dietlibc.
+// Simplified semantics on strcmp.
 #define strequal(a, b) (strcmp((a), (b)) == 0)
-// simplified semantics on strcmp.
-// int strequal(const char *a, const char *b);
 
-// convert global_arg to an integer value.
+// Convert global_arg to an integer value.
 int helper_arg_to_uint(const char *arg, int base, int maxValue);
 
 #define EMPTY_STRING ""
 extern const char empty_string[];
+
+extern const char helper_str__malloc_failed[];
 
 #endif /* _FS_SHELL__HELPERS_ */

--- a/src/main.c
+++ b/src/main.c
@@ -43,7 +43,7 @@ int main(const int argc, char *argv[]) {
 
     // Initialize the argument parser.
     int ret = args_setup_tokenizer(argc, argv);
-    if (!ret) {
+    if (ret == 0) {
         // Run all the commands
         ret = command_runner();
     }

--- a/tests/arg-c-parse.sh
+++ b/tests/arg-c-parse.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-# desc: arguments as-is must not be escaped.
+# desc: parse arguments explicitly
 # requires: +echo
 
 # This reuses the echo-args test but with required explicit string parsing.
 
-"${FS}" echo "a \\n b c" > out.txt 2>err.txt
+"${FS}" -c "echo a b 123 a123 \"a b c\"" > out.txt 2>err.txt
 res=$?
 
 if [ ${res} -ne 0 ] ; then
@@ -19,8 +19,7 @@ if [ -s err.txt ] ; then
     cat err.txt
     exit 1
 fi
-# bash will turn \\ into \, but then printf will do additional unescaping.
-if [ "$( printf "a \\\\n b c" )" != "$( cat out.txt )" ] ; then
+if [ "$( printf "a\\nb\\n123\\na123\\na b c\\n" )" != "$( cat out.txt )" ] ; then
     echo "Generated stdout not as expected:"
     cat out.txt
     exit 1

--- a/tests/arg-file-not-exist.sh
+++ b/tests/arg-file-not-exist.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# desc: argument parsing with commands from stdin
+# desc: argument parsing with commands from a file on the arguments, which does not exist
 # requires: +input
 
 "${FS}" -f not-a-file.txt > out.txt 2>err.txt

--- a/tests/arg-parse.sh
+++ b/tests/arg-parse.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 
-# desc: parse arguments explicitly
+# desc: inline arguments are parsed as though they are separated by a single space.
 # requires: +echo
 
-# This reuses the echo-args test but with required explicit string parsing.
-
-"${FS}" -c "echo a b 123 a123 \"a b c\"" > out.txt 2>err.txt
+"${FS}" echo \"a   \\n    b    c\" "&&" echo a   b   c > out.txt 2>err.txt
 res=$?
 
 if [ ${res} -ne 0 ] ; then
@@ -19,7 +17,9 @@ if [ -s err.txt ] ; then
     cat err.txt
     exit 1
 fi
-if [ "$( printf "a\\nb\\n123\\na123\\na b c\\n" )" != "$( cat out.txt )" ] ; then
+
+# Note that the \\n b has the space after the newline, which is expected.
+if [ "$( printf "a \\n b c\\na\\nb\\nc\\n" )" != "$( cat out.txt )" ] ; then
     echo "Generated stdout not as expected:"
     cat out.txt
     exit 1

--- a/tests/echo-args.sh
+++ b/tests/echo-args.sh
@@ -3,7 +3,7 @@
 # desc: echo with arguments outputs one argument per line.
 # requires: +echo
 
-"${FS}" echo a b 123 a123 "a b c" > out.txt 2>err.txt
+"${FS}" echo a b 123 a123 \"a b c\" > out.txt 2>err.txt
 res=$?
 
 if [ ${res} -ne 0 ] ; then

--- a/tests/exec-not-a-command.sh
+++ b/tests/exec-not-a-command.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# desc: exec with a file that isn't executable.
+# requires: +exec
+
+touch not-executable
+"${FS}" exec not-executable a.txt >out.txt 2>err.txt
+res=$?
+
+if [ ${res} -ne 1 ] ; then
+    echo "Bad exit code: ${res}"
+    exit 1
+fi
+
+# -f : is a file
+if [ -f a.txt ] ; then
+    echo "Incorrectly did something with a.txt"
+    exit 1
+fi
+
+# -s : file exists and not empty
+if [ -s out.txt ] ; then
+    echo "Generated output to stdount"
+    cat out.txt
+    exit 1
+fi
+
+if [ "$( printf "ERROR exec failed to launch command not-executable\\n" )" != "$( cat err.txt )" ] ; then
+    echo "Generated unexpected stderr"
+    cat err.txt
+    exit 1
+fi
+
+# should have: out.txt and err.txt and not-executable
+count="$( ls -1A | wc -l )"
+if [ ${count} != 3 ] ; then
+    echo "Generated unexpected files:"
+    ls -lA
+    exit 1
+fi

--- a/tests/exec-run.sh
+++ b/tests/exec-run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# desc: exec with no arguments
+# desc: exec with a real executable.
 # requires: +exec
 
 touch_exec="$( which touch )"


### PR DESCRIPTION
With this, the argument parsing routine was rewritten which made the compiled version smaller.  This significantly changes how non `-c` argument parsing is handled now, and it may not be supported for v3.0.

Fixed a bug with the `exec` command when the exec call out fails.  Before, the error was ignored.  Added a test to cover this (`exec-not-a-command.sh`).

Marked REQUIRE_FULL_CMD as a top-level makefile flag.  This will need to be figured out how to make work with the input stream like flags.